### PR TITLE
Update Get-FolderList.ps1 & Get-RoboSize.ps1

### DIFF
--- a/PSFolderSize/Functions/Private/Get-FolderList.ps1
+++ b/PSFolderSize/Functions/Private/Get-FolderList.ps1
@@ -19,8 +19,8 @@ function Get-FolderList {
 
         $allFolders = Get-ChildItem -LiteralPath $BasePath -Force -Recurse | 
             Where-Object {
-                ($_.FullName -notin $OmitFolders) -and 
-                ($_.Extension -in $FindExtension)
+                ($OmitFolders -notcontains $_.FullName ) -and 
+                ($FindExtension -contains $_.Extension )
             }                
 
     #All folders
@@ -28,7 +28,7 @@ function Get-FolderList {
 
         $allFolders = Get-ChildItem -LiteralPath $BasePath -Force | 
             Where-Object {
-                $_.FullName -notin $OmitFolders
+                $OmitFolders -notcontains $_.FullName
             }
 
     #Specified folder names and look for files with a particular extension
@@ -37,8 +37,8 @@ function Get-FolderList {
         $allFolders = Get-ChildItem -LiteralPath $BasePath -Force -Recurse | 
             Where-Object {
                 ($_.FullName -match ".+$FolderName.+")   -and 
-                ($_.FullName -notin $OmitFolders) -and 
-                ($_.Extension -in $FindExtension)
+                ($OmitFolders -notcontains $_.FullName) -and 
+                ($FindExtension -contains $_.Extension)
             } 
             
     } else {
@@ -46,7 +46,7 @@ function Get-FolderList {
         $allFolders = Get-ChildItem -LiteralPath $BasePath -Force | 
             Where-Object {
                 ($_.BaseName -match "$FolderName") -and 
-                ($_.FullName -notin $OmitFolders)
+                ($OmitFolders -notcontains $_.FullName)
         }
     }
 

--- a/PSFolderSize/Functions/Private/Get-RoboSize.ps1
+++ b/PSFolderSize/Functions/Private/Get-RoboSize.ps1
@@ -3,19 +3,19 @@ function Get-RoboSize {
     param(
         [Parameter(
             Position = 0,
-            Mandatory
+            Mandatory = $true
         )]
         [string]
         $Path,
 
         [Parameter(
-
+        Mandatory = $false
         )]
         [int]
         $DecimalPrecision = 2,
 
         [Parameter(
-
+        Mandatory = $false
         )]
         [int]
         $Threads = 16


### PR DESCRIPTION
Get-folderlist:

Change -notin and -in to -notcontains and -contains to maintain compatibility with older versions.
When tested against powershell v2 the comparisons throw an error.

Get-RoboSize:

Similar issues regarding compatibility resolved.
