### PR TITLE
Improve robocopy performance

### DIFF
--- a/PSFolderSize/Functions/Private/Get-RoboSize.ps1
+++ b/PSFolderSize/Functions/Private/Get-RoboSize.ps1
@@ -33,6 +33,7 @@ function Get-RoboSize {
             "/FP",
             "/NC",
             "/NDL",
+            "/NFL",
             "/TS",
             "/XJ",
             "/R:0",
@@ -43,7 +44,7 @@ function Get-RoboSize {
         [DateTime]$startTime = [DateTime]::Now
 
         Write-Verbose "Running -> [robocopy $($Path) NULL $($args)] <-"
-        [string]$summary     = robocopy $Path NULL $args | Select-Object -Last 8
+        [string]$summary     = robocopy $Path NULL $args
         [DateTime]$endTime   = [DateTime]::Now
         [regex]$headerRegex  = '\s+Total\s*Copied\s+Skipped\s+Mismatch\s+FAILED\s+Extras'
         [regex]$dirRegex     = 'Dirs\s*:\s*(?<DirCount>\d+)(?:\s+\d+){3}\s+(?<DirFailed>\d+)\s+\d+'


### PR DESCRIPTION
Adding the `/NFL` (no file list) argument will result in robocopy pretty much only printing the summary,
thereby improving performance ~10x and making the `Select-Object` call to grab only the summary unnecessary too.

A sample comparison running `Get-FolderSize -BasePath $env:USERPROFILE -UseRobo -AddTotal` against my ~58GB home directory resulted in the following times:

Before change: ~34.24s
After change: ~2.92s