### PR TITLE
Replace use of ArrayList with List<T>

### DIFF
--- a/PSFolderSize/Functions/Public/Get-FileReport.ps1
+++ b/PSFolderSize/Functions/Public/Get-FileReport.ps1
@@ -71,8 +71,8 @@ function Get-FileReport { #Begin function Get-FileReport
 
     $foundFiles = $null
 
-    #Create array to store folder objects found with size info.
-    [System.Collections.ArrayList]$fileList = @()
+    #Create list to store folder objects found with size info.
+    [System.Collections.Generic.List[Object]]$fileList = @()
 
     #Go through each folder in the base path.
     ForEach ($file in $allFolders) {
@@ -98,7 +98,7 @@ function Get-FileReport { #Begin function Get-FileReport
         [double]$fileSizeInMB = "{0:N2}" -f ($fileSize / 1MB)
         [double]$fileSizeInGB = "{0:N2}" -f ($fileSize / 1GB)
 
-        #Here we create a custom object that we'll add to the array
+        #Here we create a custom object that we'll add to the list
         $folderObject = [PSCustomObject]@{
 
             PSTypeName    = 'PS.File.List.Result'
@@ -110,8 +110,8 @@ function Get-FileReport { #Begin function Get-FileReport
 
         }                        
 
-        #Add the object to the array
-        $fileList.Add($folderObject) | Out-Null
+        #Add the object to the list
+        $fileList.Add($folderObject)
 
     }
 
@@ -140,8 +140,8 @@ function Get-FileReport { #Begin function Get-FileReport
 
             }
 
-            #Add the object to the array
-            $fileList.Add($folderObject) | Out-Null
+            #Add the object to the list
+            $fileList.Add($folderObject)
         }   
 
     }
@@ -197,7 +197,7 @@ function Get-FileReport { #Begin function Get-FileReport
     
     }
 
-    #Return the object array with the objects selected in the order specified.
+    #Return the object list with the objects selected in the order specified.
     Return $fileList | Sort-Object SizeBytes -Descending
 
 } #End function Get-FileReport

--- a/PSFolderSize/Functions/Public/Get-FolderSize.ps1
+++ b/PSFolderSize/Functions/Public/Get-FolderSize.ps1
@@ -244,8 +244,8 @@ function Get-FolderSize {
         #Get a list of all the directories in the base path we're looking for.
         $allFolders = Get-FolderList -FolderName $FolderName -OmitFolders $OmitFolders -BasePath $BasePath
         
-        #Create array to store folder objects found with size info.
-        [System.Collections.ArrayList]$folderList = @()
+        #Create list to store folder objects found with size info.
+        [System.Collections.Generic.List[Object]]$folderList = @()
 
         #Get hostname
         $hostName = [System.Net.Dns]::GetHostByName((hostname)).HostName
@@ -303,7 +303,7 @@ function Get-FolderSize {
                 }
             }
 
-            #Here we create a custom object that we'll add to the array
+            #Here we create a custom object that we'll add to the list
             $folderObject = [PSCustomObject]@{
 
                 PSTypeName    = 'PS.Folder.List.Result'
@@ -325,8 +325,8 @@ function Get-FolderSize {
 
             }
 
-            #Add the object to the array
-            $folderList.Add($folderObject) | Out-Null
+            #Add the object to the list
+            $folderList.Add($folderObject)
 
             }
 
@@ -377,8 +377,8 @@ function Get-FolderSize {
 
             }
 
-            #Add the object to the array
-            $folderList.Add($folderObject) | Out-Null
+            #Add the object to the list
+            $folderList.Add($folderObject)
 
         }   
     }


### PR DESCRIPTION
Hello,

According to the Microsoft documentation for [ArrayList](https://docs.microsoft.com/en-us/dotnet/api/system.collections.arraylist?view=netframework-4.8#remarks), its use is discouraged and it's basically considered deprecated in favor of `List<T>` aka `[System.Collections.Generic.List[$TYPE]]` in PowerShell syntax.

Another nice thing about using `System.Collections.Generic.List` instead is that its `.Add()` method does not return a number anymore like `ArrayList` did, so those `Out-Null` calls can be - and were - removed as well.