### PR TITLE
Make robocopy regex compatible with languages other than english

### DIFF
--- a/PSFolderSize/Functions/Private/Get-RoboSize.ps1
+++ b/PSFolderSize/Functions/Private/Get-RoboSize.ps1
@@ -18,7 +18,7 @@ function Get-RoboSize {
         Mandatory = $false
         )]
         [int]
-        $Threads = 16
+        $Threads = [System.Environment]::ProcessorCount
     )
 
     if (Get-Command -Name 'robocopy') {

--- a/PSFolderSize/Functions/Private/Get-RoboSize.ps1
+++ b/PSFolderSize/Functions/Private/Get-RoboSize.ps1
@@ -46,12 +46,12 @@ function Get-RoboSize {
         Write-Verbose "Running -> [robocopy $($Path) NULL $($args)] <-"
         [string]$summary     = robocopy $Path NULL $args
         [DateTime]$endTime   = [DateTime]::Now
-        [regex]$headerRegex  = '\s+Total\s*Copied\s+Skipped\s+Mismatch\s+FAILED\s+Extras'
-        [regex]$dirRegex     = 'Dirs\s*:\s*(?<DirCount>\d+)(?:\s+\d+){3}\s+(?<DirFailed>\d+)\s+\d+'
-        [regex]$fileRegex    = 'Files\s*:\s*(?<FileCount>\d+)(?:\s+\d+){3}\s+(?<FileFailed>\d+)\s+\d+'
-        [regex]$byteRegex    = 'Bytes\s*:\s*(?<ByteCount>\d+)(?:\s+\d+){3}\s+(?<BytesFailed>\d+)\s+\d+'
-        [regex]$timeRegex    = 'Times\s*:\s*(?<TimeElapsed>\d+).*'
-        [regex]$endRegex     = 'Ended\s*:\s*(?<EndedTime>.+)'
+        [regex]$headerRegex  = '\s+[\w\.]+\s*[\w\.]+\s+[\w\.]+\s+[\w\.]+\s+[\w\.]+\s+[\w\.]+'
+        [regex]$dirRegex     = '[\w\.]+\s*:\s*(?<DirCount>\d+)(?:\s+\d+){3}\s+(?<DirFailed>\d+)\s+\d+'
+        [regex]$fileRegex    = '[\w\.]+\s*:\s*(?<FileCount>\d+)(?:\s+\d+){3}\s+(?<FileFailed>\d+)\s+\d+'
+        [regex]$byteRegex    = '[\w\.]+\s*:\s*(?<ByteCount>\d+)(?:\s+\d+){3}\s+(?<BytesFailed>\d+)\s+\d+'
+        [regex]$timeRegex    = '[\w\.]+\s*:\s*(?<TimeElapsed>\d+).*'
+        [regex]$endRegex     = '[\w\.]+\s*:\s*(?<EndedTime>.+)'
 
         Write-Verbose "Raw summary:"
         Write-Verbose ($summary | Out-String)


### PR DESCRIPTION
I noticed on machines using a system language other than english, the folder sizes when using `-UseRobo` were all returning `0`.

Looking into it, this was because the `$expectedSummary` regex did not match the output from non-english robocopy versions (yes, unfortunately Microsoft localizes many CLI tools in Windows ...)

I adapted the Regex to so that it should handle *most* languages.

A sample output from german robocopy is: 

    ------------------------------------------------------------------------------

                Insgesamt    KopiertÜbersprungenKeine Übereinstimmung    FEHLER    Extras
    Verzeich.:        239        239         0         0         0         0
      Dateien:       1892       1892         0         0         0         0
        Bytes: 2968068139 2968068139         0         0         0         0
       Zeiten:    0:00:00    0:00:00                       0:00:00   0:00:00
       Beendet: Donnerstag, 29. Oktober 2020 14:20:57

I replaced all "hardcoded" texts with `[\w\.]+` because the .NET regex engine matches Umlauts as well as other international characters (such as 日本語) with `\w` and sometimes robocopy abbreviates long words with a `.` (as can be seen in the above example).

An example regex to test this is: `'Übereinstimm.日本語' -match '[\w\.]+'`

---

I also defaulted the thred count to the processors available threads, because 16 might be a bit high for some (older) laptops.