### PR TITLE
Fix for FolderName

### DIFF
--- a/PSFolderSize/Functions/Private/Get-FolderList.ps1
+++ b/PSFolderSize/Functions/Private/Get-FolderList.ps1
@@ -62,7 +62,7 @@ function Get-FolderList {
             $allFolders = Get-ChildItem -LiteralPath $BasePath -Force | 
                 Where-Object {
 
-                    ($_.BaseName -match "$FolderName") -and 
+                    ($_.BaseName -like "$FolderName") -and 
                     ($OmitFolders -notcontains $_.FullName)
 
             }


### PR DESCRIPTION
Get-FolderSize 'C:\Users' -FolderName 'Peter' - will show the size for the folder "Peter", as well as every other folder that has Peter in it like 123Peter, Peter123 etc.. This can be achieved with "Peter*" if needed..